### PR TITLE
Add Translation for TRACKS in Main Menu and Search Menu

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -114,7 +114,7 @@ sub handleFeed {
 		url => \&getFavorites,
 		passthrough => [{ type => 'albums' }],
 	},{
-		name => cstring($client, 'PLUGIN_TIDAL_TRACKS'),
+		name => cstring($client, 'TRACKS'),
 		image => 'html/images/playall.png',
 		type => 'link',
 		url => \&getFavorites,

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -114,7 +114,7 @@ sub handleFeed {
 		url => \&getFavorites,
 		passthrough => [{ type => 'albums' }],
 	},{
-		name => cstring($client, 'TRACKS'),
+		name => cstring($client, 'PLUGIN_TIDAL_TRACKS'),
 		image => 'html/images/playall.png',
 		type => 'link',
 		url => \&getFavorites,
@@ -149,7 +149,7 @@ sub handleFeed {
 			url   => \&search,
 			passthrough => [ { type => 'albums' } ],
 		},{
-			name => cstring($client, 'TRACKS'),
+			name => cstring($client, 'PLUGIN_TIDAL_TRACKS'),
 			type  => 'search',
 			url   => \&search,
 			passthrough => [ { type => 'tracks' } ],
@@ -587,7 +587,7 @@ sub _renderCategory {
 	} if $item->{hasAlbums};
 
 	push @$items, {
-		name => cstring($client, 'TRACKS'),
+		name => cstring($client, 'PLUGIN_TIDAL_TRACKS'),
 		type  => 'link',
 		url   => $renderer,
 		passthrough => [ { path => $path, type => 'tracks' } ],

--- a/strings.txt
+++ b/strings.txt
@@ -170,3 +170,7 @@ PLUGIN_TIDAL_PROGRESS_READ_PLAYLISTS
 	FR	Récupération des listes de lecture (%s)...
 	NL	Afspeellijsten ophalen (%s)...
 
+PLUGIN_TIDAL_TRACKS
+	DE	Titel
+	EN	Tracks
+	IT	Tracce


### PR DESCRIPTION
Hi Michael,

by default the Plugin show "TRACKS" for Tracks in the Main Menu and in the Seach Section.

I modified the files that we can use Translations to show other langues for that menuentry.
I tested it in my repro and it works.

Before:
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/144c8800-c8ab-4604-819e-5334bf1cbce8)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/350dbd1c-7b64-401e-b6e1-0fce550103a5)


After the change (in German)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/8c8fb3a7-8f88-488b-8c51-47149fbc6a07)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/2d0808d9-d571-44d1-b53c-e481c24d1c42)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/1939745f-a8e6-41d8-b9c9-db01cad7d92b)

After the change (in English)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/6942de1e-d32d-4574-9d74-f8c77de21e18)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/912577/8e4ba18b-49e7-4f10-8168-86efa810fd37)


Best Regards
Daniel / TeraX

