### PR TITLE
Patch 1

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -37,7 +37,7 @@ use constant SOUND_QUALITY => {
 	LOW => 'mp4',
 	HIGH => 'mp4',
 	LOSSLESS => 'flc',
-	HI_RES_LOSSLESS => 'flc',
+	HI_RES => 'flc',
 };
 
 my $cache = Slim::Utils::Cache->new;

--- a/HTML/EN/plugins/TIDAL/settings.html
+++ b/HTML/EN/plugins/TIDAL/settings.html
@@ -31,7 +31,7 @@
 
 	[% WRAPPER setting title="PLUGIN_TIDAL_QUALITY" desc="PLUGIN_TIDAL_QUALITY_DESC" %]
 		<select class="stdedit" name="pref_quality" id="quality">
-		[% FOREACH entry IN [ ['AAC 96Kbps','LOW'], ['AAC 320Kbps', 'HIGH'], ['CD (FLAC)','LOSSLESS'], ['HIRES (FLAC)', 'HI_RES_LOSSLESS'] ] %]
+		[% FOREACH entry IN [ ['AAC 96Kbps','LOW'], ['AAC 320Kbps', 'HIGH'], ['CD (FLAC)','LOSSLESS'], ['HIRES (FLAC)', 'HI_RES'] ] %]
 			<option [% IF entry.1 == prefs.pref_quality %]selected[% END %] value="[% entry.1 %]">[% entry.0 %]</option>
 		[% END %]
 		</select>


### PR DESCRIPTION
Replace HI_RES_LOSSLESS with HI_RES in api.pm and settings.html
i.e. TIDAL streams MQA FLAC (limited to 48k 24-bit if unfolded, up to 96k 24-bit if folded by DAC)

Previously, when set to HI_RES_LOSSLESS, if MQA version is not available, it results in unauthorized error.
Now, when set to HI_RES, if MQA version is not available, it selects LOSSLESS (CD quality)