### PR TITLE
disable cache in favorite when looking up

### DIFF
--- a/API/Async.pm
+++ b/API/Async.pm
@@ -274,6 +274,7 @@ sub getFavorites {
 			$cb->($items);
 		},{
 			_ttl => USER_CONTENT_TTL,
+			_nocache => 1,
 			limit => MAX_LIMIT,
 		});
 	};

--- a/API/Async.pm
+++ b/API/Async.pm
@@ -252,7 +252,7 @@ sub playlist {
 # lookup to get the latest timestamp first, then return from cache directly
 # if the list hasn't changed, or look up afresh if needed.
 sub getFavorites {
-	my ($self, $cb, $type) = @_;
+	my ($self, $cb, $type, $drill) = @_;
 
 	return $cb->() unless $type;
 
@@ -280,7 +280,10 @@ sub getFavorites {
 
 	# use cached data unless the collection has changed or is small anyway
 	my $cached = $cache->get($cacheKey);
-	if ($cached && ref $cached->{items} && scalar @{$cached->{items}} > DEFAULT_LIMIT) {
+	if ($cached && ref $cached->{items}) {
+		# don't bother verifying timestamp when drilling down
+		return $cb->($cached->{items}) if $drill;
+		
 		$self->getLatestCollectionTimestamp(sub {
 			my $timestamp = shift || 0;
 

--- a/API/Async.pm
+++ b/API/Async.pm
@@ -278,7 +278,7 @@ sub getFavorites {
 		});
 	};
 
-	# use cached data unless the collection has changed or is small anyway
+	# use cached data unless the collection has changed
 	my $cached = $cache->get($cacheKey);
 	if ($cached && ref $cached->{items}) {
 		# don't bother verifying timestamp when drilling down

--- a/API/Async.pm
+++ b/API/Async.pm
@@ -273,7 +273,6 @@ sub getFavorites {
 
 			$cb->($items);
 		},{
-			_ttl => USER_CONTENT_TTL,
 			_nocache => 1,
 			limit => MAX_LIMIT,
 		});

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -272,7 +272,7 @@ sub getFavorites {
 		$cb->( {
 			items => $items
 		} );
-	}, $params->{type});
+	}, $params->{type}, $args->{quantity} == 1 );
 }
 
 sub getArtistAlbums {


### PR DESCRIPTION
I think that, in Favorites, when we decide to get data, we should disable cache in any way because this layer has decided that cache is not what it wants so don't let _get-) lower layer return cached data