### PR TITLE
Improve "More on TIDAL" menu for tracks

### DIFF
--- a/API/Async.pm
+++ b/API/Async.pm
@@ -128,6 +128,20 @@ sub artistTopTracks {
 	});
 }
 
+sub trackRadio {
+	my ($self, $cb, $id) = @_;
+
+	$self->_get("/tracks/$id/radio", sub {
+		my $result = shift;
+		my $tracks = Plugins::TIDAL::API->cacheTrackMetadata($result->{items}) if $result;
+		$cb->($tracks || []);
+	},{
+		limit => MAX_LIMIT,
+		_ttl => 3600,
+		_personal => 1
+	});
+}
+
 # try to remove duplicates
 sub _filterAlbums {
 	my ($albums) = shift || return;

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -324,6 +324,7 @@ sub trackInfoMenu {
 	my $tid = $track->remote ? $remoteMeta->{id} : undef;
 	push @$items, {
 		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),
+		type => 'playlist',
 		url => \&getTrackRadio,
 		image => 'plugins/TIDAL/html/mix_MTL_svg_stream.png',
 		passthrough => [{ id => $tid }],

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -321,6 +321,14 @@ sub trackInfoMenu {
 		} ],
 	} if $title;
 
+	my $tid = $track->remote ? $remoteMeta->{id} : undef;
+	push @$items, {
+		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),
+		url => \&getTrackRadio,
+		image => 'plugins/TIDAL/html/mix_MTL_svg_stream.png',
+		passthrough => [{ id => $tid }],
+	} if $tid;
+
 	return {
 		type => 'outlink',
 		items => $items,
@@ -495,6 +503,17 @@ sub getArtistTopTracks {
 	my ( $client, $cb, $args, $params ) = @_;
 
 	getAPIHandler($client)->artistTopTracks(sub {
+		my $items = _renderTracks(@_);
+		$cb->( {
+			items => $items
+		} );
+	}, $params->{id});
+}
+
+sub getTrackRadio {
+	my ( $client, $cb, $args, $params ) = @_;
+
+	getAPIHandler($client)->trackRadio(sub {
 		my $items = _renderTracks(@_);
 		$cb->( {
 			items => $items

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -289,7 +289,7 @@ sub trackInfoMenu {
 	my $search = cstring($client, 'SEARCH');
 	my $items = [];
 	push @$items, {
-		name => "$search " . cstring($client, 'ARTISTS') . " '$artist'",
+		name => "$search " . cstring($client, 'ARTIST') . " '$artist'",
 		type => 'link',
 		url => \&search,
 		image => 'html/images/artists.png',
@@ -300,7 +300,7 @@ sub trackInfoMenu {
 	} if $artist;
 
 	push @$items, {
-		name => "$search " . cstring($client, 'ALBUMS') . " '$album'",
+		name => "$search " . cstring($client, 'ALBUM') . " '$album'",
 		type => 'link',
 		url => \&search,
 		image => 'html/images/albums.png',
@@ -311,7 +311,7 @@ sub trackInfoMenu {
 	} if $album;
 
 	push @$items, {
-		name => "$search " . cstring($client, 'SONGS') . " '$title'",
+		name => "$search " . cstring($client, 'SONG') . " '$title'",
 		type => 'link',
 		url => \&search,
 		image => 'html/images/playall.png',

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -283,7 +283,7 @@ sub trackInfoMenu {
 	$extid ||= $url if $url =~ /^tidal:/;
 
 	my $artist = $track->remote ? $remoteMeta->{artist} : $track->artistName;
-	my $album  = $track->remote ? $remoteMeta->{album} : ( $track->album ? $track->album->name : undef );
+	my $album  = $track->remote ? $remoteMeta->{album} : $track->albumname;
 	my $title  = $track->remote ? $remoteMeta->{title} : $track->title;
 
 	my $search = cstring($client, 'SEARCH');

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -321,7 +321,7 @@ sub trackInfoMenu {
 		} ],
 	} if $title;
 
-	my $tid = $track->remote ? $remoteMeta->{id} : undef;
+	my $tid = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
 	push @$items, {
 		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),
 		type => 'playlist',

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -282,12 +282,50 @@ sub trackInfoMenu {
 	my $extid = $track->extid;
 	$extid ||= $url if $url =~ /^tidal:/;
 
-	return _objInfoMenu($client,
-		$extid,
-		$track->artistName || $remoteMeta->{artist},
-		$track->album ? $track->albumname : $remoteMeta->{album},
-		$track->title || $remoteMeta->{title},
-	);
+	my $artist = $track->remote ? $remoteMeta->{artist} : $track->artistName;
+	my $album  = $track->remote ? $remoteMeta->{album} : ( $track->album ? $track->album->name : undef );
+	my $title  = $track->remote ? $remoteMeta->{title} : $track->title;
+
+	my $search = cstring($client, 'SEARCH');
+	my $items = [];
+	push @$items, {
+		name => "$search " . cstring($client, 'ARTISTS') . " '$artist'",
+		type => 'link',
+		url => \&search,
+		image => 'html/images/artists.png',
+		passthrough => [ {
+			type => 'artists',
+			query => $artist,
+		} ],
+	} if $artist;
+
+	push @$items, {
+		name => "$search " . cstring($client, 'ALBUMS') . " '$album'",
+		type => 'link',
+		url => \&search,
+		image => 'html/images/albums.png',
+		passthrough => [ {
+			type => 'albums',
+			query => $album,
+		} ],
+	} if $album;
+
+	push @$items, {
+		name => "$search " . cstring($client, 'SONGS') . " '$title'",
+		type => 'link',
+		url => \&search,
+		image => 'html/images/playall.png',
+		passthrough => [ {
+			type => 'tracks',
+			query => $title,
+		} ],
+	} if $title;
+
+	return {
+		type => 'outlink',
+		items => $items,
+		name => cstring($client, 'PLUGIN_TIDAL_ON_TIDAL'),
+	};
 }
 
 sub artistInfoMenu {


### PR DESCRIPTION
Make the more submenu more useful for queued tracks.

- Add Track Radio
- Add search for artist, album name, title on TIDAL

![image](https://github.com/michaelherger/lms-plugin-tidal/assets/8558/f427abda-d26c-4430-b351-5fa068421762)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/8558/68fe18aa-9b13-4d25-9472-4d909ee4ce22)
![image](https://github.com/michaelherger/lms-plugin-tidal/assets/8558/334823dd-2308-4d3f-a285-e9adcb113a82)
