### PR TITLE
Add direct links to the current album and artist to the more menu

### DIFF
--- a/API.pm
+++ b/API.pm
@@ -158,6 +158,7 @@ sub cacheTrackMetadata {
 			artist => $entry->{artist},
 			artists => $entry->{artists},
 			album => $entry->{album}->{title},
+			album_id => $entry->{album}->{id},
 			duration => $entry->{duration},
 			icon => $icon,
 			cover => $icon,

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -289,6 +289,7 @@ sub trackInfoMenu {
 	my $search = cstring($client, 'SEARCH');
 	my $items = [];
 
+	my $artists = $track->remote ? $remoteMeta->{artists} : [];
 	my $albumId = $track->remote ? $remoteMeta->{album_id} : undef;
 	my $trackId = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
 
@@ -302,6 +303,10 @@ sub trackInfoMenu {
 		image => 'html/images/albums.png',
 		passthrough => [{ id => $albumId }],
 	} if $albumId;
+
+	foreach my $_artist (@$artists) {
+		push @$items, _renderArtist($client, $_artist);
+	}
 
 	push @$items, {
 		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -290,6 +290,7 @@ sub trackInfoMenu {
 	my $items = [];
 
 	my $albumId = $track->remote ? $remoteMeta->{album_id} : undef;
+	my $trackId = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
 
 	push @$items, {
 		name => $album,
@@ -302,14 +303,13 @@ sub trackInfoMenu {
 		passthrough => [{ id => $albumId }],
 	} if $albumId;
 
-	my $tid = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
 	push @$items, {
 		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),
 		type => 'playlist',
 		url => \&getTrackRadio,
 		image => 'plugins/TIDAL/html/mix_MTL_svg_stream.png',
-		passthrough => [{ id => $tid }],
-	} if $tid;
+		passthrough => [{ id => $trackId }],
+	} if $trackId;
 
 	push @$items, {
 		name => "$search " . cstring($client, 'ARTIST') . " '$artist'",

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -279,8 +279,9 @@ sub trackInfoMenu {
 	my ( $client, $url, $track, $remoteMeta ) = @_;
 	$remoteMeta ||= {};
 
+	my $isTidalTrack = $url =~ /^tidal:/;
 	my $extid = $track->extid;
-	$extid ||= $url if $url =~ /^tidal:/;
+	$extid ||= $url if $isTidalTrack;
 
 	my $artist = $track->remote ? $remoteMeta->{artist} : $track->artistName;
 	my $album  = $track->remote ? $remoteMeta->{album} : $track->albumname;
@@ -289,8 +290,8 @@ sub trackInfoMenu {
 	my $search = cstring($client, 'SEARCH');
 	my $items = [];
 
-	my $artists = $track->remote ? $remoteMeta->{artists} : [];
-	my $albumId = $track->remote ? $remoteMeta->{album_id} : undef;
+	my $artists = ($track->remote && $isTidalTrack) ? $remoteMeta->{artists} : [];
+	my $albumId = ($track->remote && $isTidalTrack) ? $remoteMeta->{album_id} : undef;
 	my $trackId = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
 
 	push @$items, {

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -288,6 +288,29 @@ sub trackInfoMenu {
 
 	my $search = cstring($client, 'SEARCH');
 	my $items = [];
+
+	my $albumId = $track->remote ? $remoteMeta->{album_id} : undef;
+
+	push @$items, {
+		name => $album,
+		line1 => $album,
+		line2 => $artist,
+		favorites_url => 'tidal://album:' . $albumId,
+		type => 'playlist',
+		url => \&getAlbum,
+		image => 'html/images/albums.png',
+		passthrough => [{ id => $albumId }],
+	} if $albumId;
+
+	my $tid = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
+	push @$items, {
+		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),
+		type => 'playlist',
+		url => \&getTrackRadio,
+		image => 'plugins/TIDAL/html/mix_MTL_svg_stream.png',
+		passthrough => [{ id => $tid }],
+	} if $tid;
+
 	push @$items, {
 		name => "$search " . cstring($client, 'ARTIST') . " '$artist'",
 		type => 'link',
@@ -320,15 +343,6 @@ sub trackInfoMenu {
 			query => $title,
 		} ],
 	} if $title;
-
-	my $tid = Plugins::TIDAL::ProtocolHandler::_getId($track->url);
-	push @$items, {
-		name => cstring($client, 'PLUGIN_TIDAL_TRACK_MIX'),
-		type => 'playlist',
-		url => \&getTrackRadio,
-		image => 'plugins/TIDAL/html/mix_MTL_svg_stream.png',
-		passthrough => [{ id => $tid }],
-	} if $tid;
 
 	return {
 		type => 'outlink',


### PR DESCRIPTION
That's the start of the more menu:

![image](https://github.com/michaelherger/lms-plugin-tidal/assets/8558/d3b578bc-97d1-4c6a-a1d0-83064451a3c0)

I still think searching for an artist/album/song name still relevant; but the direct links are very common.  

